### PR TITLE
Fix for breaking change in Prometheus Golang Client

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mxschmitt/fritzbox_exporter/pkg/fritzboxmetrics"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const serviceLoadRetryTime = 1 * time.Minute
@@ -382,6 +383,6 @@ func main() {
 	prometheus.MustRegister(collector)
 	prometheus.MustRegister(collectErrors)
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(settings.ListenAddr, nil))
 }


### PR DESCRIPTION
Version 1.0 removed the previously deprecated prometheus.handler() function. It is now provided by the promhttp package.

Without this fix builds of _fritzbox_exporter_ program will fail.