### PR TITLE
feat: docker images for ARM

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,20 @@
+FROM golang AS build-env
+
+LABEL maintainer="Max Schmitt <max@schmitt.mx>"
+LABEL description="FRITZ!Box Prometheus exporter"
+
+ADD . /go/src/github.com/mxschmitt/fritzbox_exporter
+
+RUN cd /go/src/github.com/mxschmitt/fritzbox_exporter/cmd/exporter && \
+    go get -v ./... && \
+    CGO_ENABLED=0 COOS=linux GOARCH=arm go build -o /exporter
+
+FROM arm32v7/alpine
+
+RUN apk update && apk add --no-cache ca-certificates
+
+COPY --from=build-env /exporter /
+
+EXPOSE 9133
+
+ENTRYPOINT ["/exporter"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,20 @@
+FROM golang AS build-env
+
+LABEL maintainer="Max Schmitt <max@schmitt.mx>"
+LABEL description="FRITZ!Box Prometheus exporter"
+
+ADD . /go/src/github.com/mxschmitt/fritzbox_exporter
+
+RUN cd /go/src/github.com/mxschmitt/fritzbox_exporter/cmd/exporter && \
+    go get -v ./... && \
+    CGO_ENABLED=0 COOS=linux GOARCH=arm64 go build -o /exporter
+
+FROM arm64v8/alpine
+
+RUN apk update && apk add --no-cache ca-certificates
+
+COPY --from=build-env /exporter /
+
+EXPOSE 9133
+
+ENTRYPOINT ["/exporter"]


### PR DESCRIPTION
Dockerfiles for 32 and 64 bit ARM devices.

I pushed images of these builds to [Docker Hub](https://hub.docker.com/r/orangefoil/fritzbox_exporter/tags). They also include the changes from PR #11.  
Should this PR get accepted, I'd like to propose to put these ARM images into @mxschmitt's Docker Hub repository [mxschmitt/fritzbox_exporter](https://hub.docker.com/r/mxschmitt/fritzbox_exporter).