### PR TITLE
Replace TotalBytesSent and TotalBytesReceived

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -77,7 +77,7 @@ var metrics = []*Metric{
 	{
 		Service: "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
 		Action:  "GetAddonInfos",
-		Result:  "TotalBytesReceived",
+		Result:  "X_AVM_DE_TotalBytesReceived64",
 		Desc: prometheus.NewDesc(
 			"gateway_wan_bytes_received",
 			"bytes received on gateway WAN interface",
@@ -89,7 +89,7 @@ var metrics = []*Metric{
 	{
 		Service: "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1",
 		Action:  "GetAddonInfos",
-		Result:  "TotalBytesSent",
+		Result:  "X_AVM_DE_TotalBytesSent64",
 		Desc: prometheus.NewDesc(
 			"gateway_wan_bytes_sent",
 			"bytes sent on gateway WAN interface",

--- a/pkg/fritzboxmetrics/fritzboxmetrics.go
+++ b/pkg/fritzboxmetrics/fritzboxmetrics.go
@@ -297,6 +297,15 @@ func (a *Action) parseSoapResponse(r io.Reader) (Result, error) {
 }
 
 func convertResult(val string, arg *Argument) (interface{}, error) {
+  switch arg.StateVariable.Name {
+  case "X_AVM_DE_TotalBytesSent64", "X_AVM_DE_TotalBytesReceived64":
+		res, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return nil, errors.Wrap(err, "could nto parse uint")
+		}
+		return uint64(res), nil
+  }
+
 	switch arg.StateVariable.DataType {
 	case "string":
 		return val, nil

--- a/pkg/fritzboxmetrics/fritzboxmetrics.go
+++ b/pkg/fritzboxmetrics/fritzboxmetrics.go
@@ -301,7 +301,7 @@ func convertResult(val string, arg *Argument) (interface{}, error) {
   case "X_AVM_DE_TotalBytesSent64", "X_AVM_DE_TotalBytesReceived64":
 		res, err := strconv.ParseUint(val, 10, 64)
 		if err != nil {
-			return nil, errors.Wrap(err, "could nto parse uint")
+			return nil, errors.Wrap(err, "could not parse uint")
 		}
 		return uint64(res), nil
   }


### PR DESCRIPTION
replace both variables through the 64 byte ones
because the variables are formatted as a string there is an additional
change in fritzboxmetrics.go